### PR TITLE
README: Fix installation instructions of "With Git"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ the Hex Converter folder to your Sublime Text 2 "Packages" directory.
 
 **With Git:** Clone the repository in your Sublime Text 2 "Packages" directory:
 
-    git clone https://github.com/HackerBaloo/SublimeHexConverter
+    git clone https://github.com/HackerBaloo/SublimeHexConverter "Hex Converter"
 
 The "Packages" directory can be found in the following locations:
 


### PR DESCRIPTION
Cloned folder should be named "Hex Converter" to be able to use settings files from menu
_Preferences -> Package Settings -> Hex Converter_ which are referenced to files in "Hex Converter" folder.
